### PR TITLE
Handles edge cases where blocks failed to parse

### DIFF
--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -180,7 +180,7 @@ module SyntaxTree
         end
       end
 
-      # Visit an HtmlString node.
+      # Visit a HtmlString node.
       def visit_html_string(node)
         q.group do
           visit(node.opening)

--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -78,9 +78,11 @@ module SyntaxTree
       end
 
       def visit_erb_do_close(node)
-        q.text(node.value.rstrip)
-        q.text(" ")
-        q.text(node.closing)
+        visit(node.closing)
+      end
+
+      def visit_erb_close(node)
+        visit(node.closing)
       end
 
       # Visit an ErbIf node.
@@ -175,6 +177,15 @@ module SyntaxTree
           visit(node.key)
           visit(node.equals)
           visit(node.value)
+        end
+      end
+
+      # Visit an HtmlString node.
+      def visit_html_string(node)
+        q.group do
+          visit(node.opening)
+          q.seplist(node.contents, -> { "" }) { |child_node| visit(child_node) }
+          visit(node.closing)
         end
       end
 

--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -183,9 +183,9 @@ module SyntaxTree
       # Visit a HtmlString node.
       def visit_html_string(node)
         q.group do
-          visit(node.opening)
+          q.text("\"")
           q.seplist(node.contents, -> { "" }) { |child_node| visit(child_node) }
-          visit(node.closing)
+          q.text("\"")
         end
       end
 

--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -189,15 +189,6 @@ module SyntaxTree
         end
       end
 
-      # Visit an ErbString node.
-      def visit_erb_string(node)
-        q.group do
-          visit(node.opening)
-          q.seplist(node.contents, -> { "" }) { |child_node| visit(child_node) }
-          visit(node.closing)
-        end
-      end
-
       # Visit a CharData node.
       def visit_char_data(node)
         lines = node.value.value.strip.split("\n")

--- a/lib/syntax_tree/erb/nodes.rb
+++ b/lib/syntax_tree/erb/nodes.rb
@@ -291,26 +291,9 @@ module SyntaxTree
       end
     end
 
-    class ErbDoClose < Node
-      attr_reader :location, :closing
-
-      def initialize(location:, closing:)
-        @location = location
-        @closing = closing
-      end
-
+    class ErbDoClose < ErbClose
       def accept(visitor)
         visitor.visit_erb_do_close(self)
-      end
-
-      def child_nodes
-        []
-      end
-
-      alias deconstruct child_nodes
-
-      def deconstruct_keys(keys)
-        { location: location, closing: closing }
       end
     end
 
@@ -439,7 +422,7 @@ module SyntaxTree
       end
     end
 
-    # An HtmlString can include ERB-tags
+    # A HtmlString can include ERB-tags
     class HtmlString < Node
       attr_reader :opening, :contents, :closing, :location
 

--- a/lib/syntax_tree/erb/nodes.rb
+++ b/lib/syntax_tree/erb/nodes.rb
@@ -439,40 +439,6 @@ module SyntaxTree
       end
     end
 
-    class ErbString < Node
-      attr_reader :opening, :contents, :closing, :location
-
-      def initialize(opening:, contents:, closing:, location:)
-        @opening = opening
-        @contents = contents
-        @closing = closing
-        @location = location
-      end
-
-      def accept(visitor)
-        visitor.visit_erb_string(self)
-      end
-
-      def child_nodes
-        [*contents]
-      end
-
-      def value
-        "\"#{contents.map(&:value).join}\""
-      end
-
-      alias deconstruct child_nodes
-
-      def deconstruct_keys(keys)
-        {
-          opening: opening,
-          contents: contents,
-          closing: closing,
-          location: location
-        }
-      end
-    end
-
     # An HtmlString can include ERB-tags
     class HtmlString < Node
       attr_reader :opening, :contents, :closing, :location

--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -470,7 +470,7 @@ module SyntaxTree
         content = parse_until_erb_close
         closing_tag = content.pop
 
-        unless closing_tag.is_a?(ErbDoClose) || closing_tag.is_a?(ErbClose)
+        if !closing_tag.is_a?(ErbClose)
           raise(
             ParseError,
             "Found no matching closing tag for the erb-tag at #{opening_tag.location}"
@@ -525,7 +525,7 @@ module SyntaxTree
               maybe { consume(:erb_code) }
           items << result
 
-          break if result.is_a?(ErbDoClose) || result.is_a?(ErbClose)
+          break if result.is_a?(ErbClose)
         end
 
         items

--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -107,7 +107,7 @@ module SyntaxTree
                 state << :inside
               when /\A"/
                 # the beginning of a string
-                enum.yield :string_open, $&, index, line
+                enum.yield :string_open_double_quote, $&, index, line
                 state << :string
               when /\A[^<]+/
                 # plain text content
@@ -162,12 +162,16 @@ module SyntaxTree
               when /\A[\n]+/
                 # whitespace
                 line += $&.count("\n")
-              when /\Ado\s*.*?\s*%>/
+              when /\Ado\b(\s*\|[\w\s,]+\|)?\s*-?%>/
                 enum.yield :erb_do_close, $&, index, line
                 state.pop
               when /\A-?%>/
                 enum.yield :erb_close, $&, index, line
                 state.pop
+              when /\A\w*\b/
+                # Split by word boundary while parsing the code
+                # This allows us to separate what_to_do vs do
+                enum.yield :erb_code, $&, index, line
               else
                 enum.yield :erb_code, source[index], index, line
                 index += 1
@@ -181,7 +185,7 @@ module SyntaxTree
                 line += $&.count("\n")
               when /\A\"/
                 # the end of a quoted string
-                enum.yield :string_close, $&, index, line
+                enum.yield :string_close_double_quote, $&, index, line
                 state.pop
               when /\A<%[=]?/
                 # the beginning of an ERB tag
@@ -239,7 +243,7 @@ module SyntaxTree
                 state << :erb
               when /\A"/
                 # the beginning of a string
-                enum.yield :string_open, $&, index, line
+                enum.yield :string_open_double_quote, $&, index, line
                 state << :string
               else
                 raise ParseError,
@@ -462,17 +466,22 @@ module SyntaxTree
           maybe { consume(:erb_if) } || maybe { consume(:erb_unless) } ||
             maybe { consume(:erb_elsif) } || maybe { consume(:erb_else) } ||
             maybe { consume(:erb_end) }
-        content = many { consume(:erb_code) }
-        closing_tag =
-          atleast do
-            maybe { consume(:erb_close) } || maybe { parse_erb_do_close }
-          end
+
+        content = parse_until_erb_close
+        closing_tag = content.pop
+
+        unless closing_tag.is_a?(ErbDoClose) || closing_tag.is_a?(ErbClose)
+          raise(
+            ParseError,
+            "Found no matching closing tag for the erb-tag at #{opening_tag.location}"
+          )
+        end
 
         erb_node =
           ErbNode.new(
             opening_tag: opening_tag,
             keyword: keyword,
-            content: content.map(&:value).join,
+            content: content,
             closing_tag: closing_tag,
             location: opening_tag.location.to(closing_tag.location)
           )
@@ -486,7 +495,7 @@ module SyntaxTree
           parse_erb_end(erb_node)
         else
           if closing_tag.is_a?(ErbDoClose)
-            elements = parse_until_erb(classes: [ErbEnd])
+            elements = maybe { parse_until_erb(classes: [ErbEnd]) } || []
             erb_end = elements.pop
 
             unless erb_end.is_a?(ErbEnd)
@@ -507,26 +516,45 @@ module SyntaxTree
         end
       end
 
+      def parse_until_erb_close
+        items = []
+
+        loop do
+          result =
+            maybe { parse_erb_do_close } || maybe { parse_erb_close } ||
+              maybe { consume(:erb_code) }
+          items << result
+
+          break if result.is_a?(ErbDoClose) || result.is_a?(ErbClose)
+        end
+
+        items
+      end
+
       def parse_blank_line
         blank_line = consume(:blank_line)
 
         CharData.new(value: blank_line, location: blank_line.location)
       end
 
-      def parse_erb_do_close
-        token = consume(:erb_do_close)
+      def parse_erb_close
+        closing = consume(:erb_close)
 
-        closing = token.value.match(/-?%>$/).to_s
-
-        ErbDoClose.new(
-          location: token.location,
-          value: token.value.gsub(closing, ""),
-          closing: closing
-        )
+        ErbClose.new(location: closing.location, closing: closing)
       end
 
-      def parse_string
-        opening = consume(:string_open)
+      def parse_erb_do_close
+        closing = consume(:erb_do_close)
+
+        ErbDoClose.new(location: closing.location, closing: closing)
+      end
+
+      def parse_html_string
+        opening =
+          atleast do
+            maybe { consume(:string_open_double_quote) } ||
+              maybe { consume(:string_open_single_quote) }
+          end
         contents =
           many do
             atleast do
@@ -534,9 +562,15 @@ module SyntaxTree
                 maybe { parse_erb_tag }
             end
           end
-        closing = consume(:string_close)
 
-        ErbString.new(
+        closing =
+          if opening.type == :string_open_double_quote
+            consume(:string_close_double_quote)
+          else
+            consume(:string_close_single_quote)
+          end
+
+        HtmlString.new(
           opening: opening,
           contents: contents,
           closing: closing,
@@ -556,7 +590,7 @@ module SyntaxTree
             location: key.location
           )
         else
-          value = parse_string
+          value = parse_html_string
 
           HtmlAttribute.new(
             key: key,

--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -637,11 +637,10 @@ module SyntaxTree
           many do
             atleast do
               maybe { consume(:string_open_double_quote) } ||
-              maybe { consume(:string_open_single_quote) } ||
-              maybe { consume(:string_close_double_quote) } ||
-              maybe { consume(:string_close_single_quote) } ||
-              maybe { consume(:text) } ||
-              maybe { consume(:whitespace) }
+                maybe { consume(:string_open_single_quote) } ||
+                maybe { consume(:string_close_double_quote) } ||
+                maybe { consume(:string_close_single_quote) } ||
+                maybe { consume(:text) } || maybe { consume(:whitespace) }
             end
           end
 

--- a/lib/syntax_tree/erb/pretty_print.rb
+++ b/lib/syntax_tree/erb/pretty_print.rb
@@ -106,6 +106,11 @@ module SyntaxTree
         visit_node("attribute", node)
       end
 
+      # Visit an HtmlString node.
+      def visit_html_string(node)
+        visit_node("html_string", node)
+      end
+
       # Visit an ErbString node.
       def visit_erb_string(node)
         visit_node("erb_string", node)
@@ -114,6 +119,10 @@ module SyntaxTree
       # Visit a CharData node.
       def visit_char_data(node)
         visit_node("char_data", node)
+      end
+
+      def visit_erb_close(node)
+        visit_node("erb_close", node)
       end
 
       def visit_erb_do_close(node)

--- a/lib/syntax_tree/erb/pretty_print.rb
+++ b/lib/syntax_tree/erb/pretty_print.rb
@@ -111,11 +111,6 @@ module SyntaxTree
         visit_node("html_string", node)
       end
 
-      # Visit an ErbString node.
-      def visit_erb_string(node)
-        visit_node("erb_string", node)
-      end
-
       # Visit a CharData node.
       def visit_char_data(node)
         visit_node("char_data", node)

--- a/lib/syntax_tree/erb/pretty_print.rb
+++ b/lib/syntax_tree/erb/pretty_print.rb
@@ -106,7 +106,7 @@ module SyntaxTree
         visit_node("attribute", node)
       end
 
-      # Visit an HtmlString node.
+      # Visit a HtmlString node.
       def visit_html_string(node)
         visit_node("html_string", node)
       end

--- a/lib/syntax_tree/erb/visitor.rb
+++ b/lib/syntax_tree/erb/visitor.rb
@@ -50,6 +50,9 @@ module SyntaxTree
       # Visit an ErbNode node.
       alias visit_erb visit_child_nodes
 
+      # Visit an HtmlString node.
+      alias visit_html_string visit_child_nodes
+
       # Visit an ErbString node.
       alias visit_erb_string visit_child_nodes
     end

--- a/lib/syntax_tree/erb/visitor.rb
+++ b/lib/syntax_tree/erb/visitor.rb
@@ -52,9 +52,6 @@ module SyntaxTree
 
       # Visit an HtmlString node.
       alias visit_html_string visit_child_nodes
-
-      # Visit an ErbString node.
-      alias visit_erb_string visit_child_nodes
     end
   end
 end

--- a/lib/syntax_tree/erb/visitor.rb
+++ b/lib/syntax_tree/erb/visitor.rb
@@ -50,7 +50,7 @@ module SyntaxTree
       # Visit an ErbNode node.
       alias visit_erb visit_child_nodes
 
-      # Visit an HtmlString node.
+      # Visit a HtmlString node.
       alias visit_html_string visit_child_nodes
     end
   end

--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -41,6 +41,12 @@ module SyntaxTree
       end
     end
 
+    def test_missing_erb_block_end_tag
+      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+        ERB.parse("<% no_end_tag do %>")
+      end
+    end
+
     def test_missing_html_end_tag
       assert_raises(SyntaxTree::ERB::Parser::ParseError) do
         ERB.parse("<h1>Hello World")

--- a/test/fixture/block_formatted.html.erb
+++ b/test/fixture/block_formatted.html.erb
@@ -9,3 +9,9 @@
     class: "btn btn-primary btn btn-primary btn btn-primary btn btn-primary"
   ) %>
 <% end %>
+
+<%= link_to(dont_replace, what_to_do, class: "do |what,bad|") do |hello| %>
+  <span>Should allow to use the word do in the code</span>
+<% end %>
+
+<%= this_is_not_a_do_block_do %>

--- a/test/fixture/block_unformatted.html.erb
+++ b/test/fixture/block_unformatted.html.erb
@@ -17,3 +17,8 @@
 
   <%= form.submit("Very very very very very long text", class: "btn btn-primary btn btn-primary btn btn-primary btn btn-primary") %>
 <% end %>
+
+<%= link_to(dont_replace, what_to_do, class: 'do |what,bad|') do |hello| %><span>Should allow to use the word do in the code
+</span><% end %>
+
+<%= this_is_not_a_do_block_do %>

--- a/test/fixture/nested_html_formatted.html.erb
+++ b/test/fixture/nested_html_formatted.html.erb
@@ -1,5 +1,6 @@
-<div>
-  <span>
+<div class="card">
+  <span class="small">
     <%= t(".title") + " " + t(".description") + " " + t(".pretty_long") %>
+    '"This is a quote within a quote"'
   </span>
 </div>

--- a/test/fixture/nested_html_unformatted.html.erb
+++ b/test/fixture/nested_html_unformatted.html.erb
@@ -1,1 +1,1 @@
-<div><span><%= t(".title") + " " + t(".description") + " " + t(".pretty_long") %></span></div>
+<div class='card'><span class='small'><%= t(".title") + " " + t(".description") + " " + t(".pretty_long") %>'"This is a quote within a quote"'</span></div>


### PR DESCRIPTION
- A block containing the word `do` generated some errors.
In
```ruby
<% what_to_do do |form| %>
```
the `do` at the end of `what_to_do` was interpreted as the start of
a block. To avoid this all erb-code is now parsed between word boundaries.
So `what_to_do` will become one Token with type `erb_code`.
