### PR TITLE
Handles non-ascii ERB-code

### DIFF
--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -173,7 +173,7 @@ module SyntaxTree
               when /\A-?%>/
                 enum.yield :erb_close, $&, index, line
                 state.pop
-              when /\A\w*\b/
+              when /\A[\p{L}\w]*\b/
                 # Split by word boundary while parsing the code
                 # This allows us to separate what_to_do vs do
                 enum.yield :erb_code, $&, index, line

--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -22,5 +22,11 @@ module SyntaxTree
         ERB.parse("<% no_end_tag do %>")
       end
     end
+
+    def test_erb_code_with_non_ascii
+      parsed = ERB.parse("<% \"Påäööööö\" %>")
+      assert_equal(1, parsed.elements.size)
+      assert_instance_of(SyntaxTree::ERB::ErbNode, parsed.elements.first)
+    end
   end
 end


### PR DESCRIPTION
The following code caused errors:
```
<%= link_to("Düsseldorf", "http://duesseldorf.de") %>
```
