### PR TITLE
Support quotes in HTML-text

### DIFF
--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -105,14 +105,6 @@ module SyntaxTree
                 # <
                 enum.yield :open, $&, index, line
                 state << :inside
-              when /\A"/
-                # the beginning of a double quoted string
-                enum.yield :string_open_double_quote, $&, index, line
-                state << :string_double_quote
-              when /\A'/
-                # the beginning of a double quoted string
-                enum.yield :string_open_single_quote, $&, index, line
-                state << :string_single_quote
               when /\A[^<]+/
                 # plain text content
                 # abc

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -46,5 +46,19 @@ module SyntaxTree
       formatted = ERB.format(source)
       assert_equal(source, formatted)
     end
+
+    def test_html_within_quotes
+      source =
+        "<p>This is our text \"<strong><%= @object.quote %></strong>\"</p>"
+      parsed = ERB.parse(source)
+      elements = parsed.elements
+
+      assert_equal(1, elements.size)
+      assert_instance_of(SyntaxTree::ERB::HtmlNode, elements.first)
+      content = elements.first.content
+
+      assert_equal("This is our text \"", content.first.value.value)
+      assert_equal("\"", content.last.value.value)
+    end
   end
 end


### PR DESCRIPTION
```html
<p>Here is a "<em><%= quote %></em>" in HTML</p>
```
