### PR TITLE
Allow html attribute to start with @:#

### DIFF
--- a/test/fixture/vue_components_formatted.html.erb
+++ b/test/fixture/vue_components_formatted.html.erb
@@ -7,5 +7,7 @@
   >
   </card-header>
 
-  <card-body :content="<%= @content %>" @click="doThis"></card-body>
+  <card-body :content="<%= @content %>" @click="doThis">
+    <template #button-content>Hello</template>
+  </card-body>
 </div>

--- a/test/fixture/vue_components_unformatted.html.erb
+++ b/test/fixture/vue_components_unformatted.html.erb
@@ -1,3 +1,3 @@
 <div class="card"><card-header :title="<%= t(".title") %>" boolean :value="['a', 'b']" :long-variable-name="data.item.javascript.code"></card-header>
 
-<card-body :content="<%= @content %>" @click="doThis"></card-body></div>
+<card-body :content="<%= @content %>" @click="doThis"><template #button-content>Hello</template></card-body></div>

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -60,5 +60,17 @@ module SyntaxTree
       assert_equal("This is our text \"", content.first.value.value)
       assert_equal("\"", content.last.value.value)
     end
+
+    def test_html_tag_names
+      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+        ERB.parse("<@br />")
+      end
+      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+        ERB.parse("<:br />")
+      end
+      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+        ERB.parse("<#br />")
+      end
+    end
   end
 end


### PR DESCRIPTION
In Vue we often use
```
<button-component>
  <template #button-content>
    Hello
  </template>
</button-component>
```
