### PR TITLE
Handles dot, dash and underscore in attribute names

### DIFF
--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -244,7 +244,7 @@ module SyntaxTree
                 # an equals sign
                 # =
                 enum.yield :equals, $&, index, line
-              when /\A[@:#]*[\w-]+\b/
+              when /\A[@:#]*[\w\.\-\_]+\b/
                 # a name for an element or an attribute
                 # strong, vue-component-kebab, VueComponentPascal
                 # abc, #abc, @abc, :abc

--- a/test/fixture/vue_components_formatted.html.erb
+++ b/test/fixture/vue_components_formatted.html.erb
@@ -1,5 +1,6 @@
 <div class="card">
   <card-header
+    v-b-modal.purchase_modal
     :title="<%= t(".title") %>"
     boolean
     :value="['a', 'b']"

--- a/test/fixture/vue_components_unformatted.html.erb
+++ b/test/fixture/vue_components_unformatted.html.erb
@@ -1,3 +1,3 @@
-<div class="card"><card-header :title="<%= t(".title") %>" boolean :value="['a', 'b']" :long-variable-name="data.item.javascript.code"></card-header>
+<div class="card"><card-header v-b-modal.purchase_modal :title="<%= t(".title") %>" boolean :value="['a', 'b']" :long-variable-name="data.item.javascript.code"></card-header>
 
 <card-body :content="<%= @content %>" @click="doThis"><template #button-content>Hello</template></card-body></div>


### PR DESCRIPTION
Vue uses syntax like `v-b-modal.name_of_the_modal` for attribute names.
