### PR TITLE
HTML: Handles attribute values without quotes

### DIFF
--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -571,10 +571,22 @@ module SyntaxTree
 
       def parse_html_string
         opening =
-          atleast do
-            maybe { consume(:string_open_double_quote) } ||
-              maybe { consume(:string_open_single_quote) }
-          end
+          maybe { consume(:string_open_double_quote) } ||
+            maybe { consume(:string_open_single_quote) }
+
+        if opening.nil?
+          value = consume(:name)
+
+          return(
+            HtmlString.new(
+              opening: nil,
+              contents: [value],
+              closing: nil,
+              location: value.location
+            )
+          )
+        end
+
         contents =
           many do
             atleast do

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -72,5 +72,22 @@ module SyntaxTree
         ERB.parse("<#br />")
       end
     end
+
+    def test_html_attribute_without_quotes
+      source = "<div class=card>Hello World</div>"
+      parsed = ERB.parse(source)
+      elements = parsed.elements
+
+      assert_equal(1, elements.size)
+      assert_instance_of(SyntaxTree::ERB::HtmlNode, elements.first)
+      assert_equal(1, elements.first.opening_tag.attributes.size)
+
+      attribute = elements.first.opening_tag.attributes.first
+      assert_equal("class", attribute.key.value)
+      assert_equal("card", attribute.value.contents.first.value)
+
+      formatted = ERB.format(source)
+      assert_equal("<div class=\"card\">Hello World</div>\n", formatted)
+    end
   end
 end


### PR DESCRIPTION
```
<div class=card></div>
```

can now be parsed and formatted as

```
<div class="card"></div>
```
