### PR TITLE
Handles Alpine.js syntax

### DIFF
--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -244,7 +244,7 @@ module SyntaxTree
                 # an equals sign
                 # =
                 enum.yield :equals, $&, index, line
-              when /\A[@:#]*[\w\.\-\_]+\b/
+              when /\A[@#]*[:\w\.\-\_]+\b/
                 # a name for an element or an attribute
                 # strong, vue-component-kebab, VueComponentPascal
                 # abc, #abc, @abc, :abc

--- a/test/fixture/javascript_frameworks_formatted.html.erb
+++ b/test/fixture/javascript_frameworks_formatted.html.erb
@@ -1,3 +1,4 @@
+<!-- Vue -->
 <div class="card">
   <card-header
     v-b-modal.purchase_modal
@@ -13,4 +14,21 @@
       Hello
     </template>
   </card-body>
+</div>
+
+<!-- Alpine -->
+<div
+  x-data="{open: false}"
+  class="absolute bottom-0"
+  x-transition:enter="transition ease-out"
+  x-transition:leave="transition ease-in"
+>
+  <button @click="open = true">
+    Expand
+  </button>
+  <span x-show="open">
+    <h1>
+      Hello
+    </h1>
+  </span>
 </div>

--- a/test/fixture/javascript_frameworks_unformatted.html.erb
+++ b/test/fixture/javascript_frameworks_unformatted.html.erb
@@ -1,3 +1,7 @@
+<!-- Vue -->
 <div class="card"><card-header v-b-modal.purchase_modal :title="<%= t(".title") %>" boolean :value="['a', 'b']" :long-variable-name="data.item.javascript.code"></card-header>
 
 <card-body :content="<%= @content %>" @click="doThis"><template #button-content>Hello</template></card-body></div>
+
+<!-- Alpine --><div x-data="{open: false}" class="absolute bottom-0" x-transition:enter="transition ease-out" x-transition:leave="transition ease-in">
+<button @click="open = true">Expand</button><span x-show="open"><h1>Hello</h1></span></div>

--- a/test/formatting_test.rb
+++ b/test/formatting_test.rb
@@ -20,8 +20,8 @@ module SyntaxTree
       assert_formatting("if_statements")
     end
 
-    def test_vue_components
-      assert_formatting("vue_components")
+    def test_javascript_frameworks
+      assert_formatting("javascript_frameworks")
     end
 
     def test_layout


### PR DESCRIPTION
- Could not parse `<div x-transition:enter="classes">` because of the colon
