### PR TITLE
Handles ternaries as arguments

### DIFF
--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -204,17 +204,26 @@ module SyntaxTree
       end
 
       def erb_print_width(syntax_tree)
-        syntax_tree => SyntaxTree::Program[
-          statements: SyntaxTree::Statements[
-            body: [SyntaxTree::IfNode | SyntaxTree::IfOp => if_node]
-          ]
-        ]
-
+        statements = syntax_tree.statements.body
         # Set the width to maximum if we have an IfNode or IfOp,
         # we cannot format them purely with SyntaxTree because the ERB-syntax will be unparseable.
-        if_node.nil? ? SyntaxTree::ERB::MAX_WIDTH : 999_999
-      rescue NoMatchingPatternError
-        SyntaxTree::ERB::MAX_WIDTH
+        if statements.any? { |node| check_for_if_statement(node) }
+          999_999
+        else
+          SyntaxTree::ERB::MAX_WIDTH
+        end
+      end
+
+      def check_for_if_statement(node)
+        return false if node.nil?
+
+        if node.is_a?(SyntaxTree::IfNode) || node.is_a?(SyntaxTree::IfOp)
+          return true
+        end
+
+        node.child_nodes.any? do |child_node|
+          check_for_if_statement(child_node)
+        end
       end
     end
   end

--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -61,5 +61,15 @@ module SyntaxTree
       assert_equal(source, formatted_once)
       assert_equal(source, formatted_twice)
     end
+
+    def test_erb_ternary_as_argument_without_parentheses
+      source =
+        "<%=     f.submit f.object.id.present?     ? t('buttons.titles.save'):t('buttons.titles.create')   %>"
+      expected =
+        "<%= f.submit f.object.id.present? ? t(\"buttons.titles.save\") : t(\"buttons.titles.create\") %>\n"
+      formatted = ERB.format(source)
+
+      assert_equal(expected, formatted)
+    end
   end
 end


### PR DESCRIPTION
- Loop recursively through all nodes and look for IfNode and IfOp
  to be able to format all ternaries with longer line length.
- Avoids some more if-statements inside other ERB-calls.
