### PR TITLE
Handles ERB-tags with multiple statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+- Handle formatting of multi-line ERB-tags with more than one statement.
+
 ## [0.9.0] - 2023-06-22
 
 ### Added

--- a/lib/syntax_tree/erb/nodes.rb
+++ b/lib/syntax_tree/erb/nodes.rb
@@ -220,8 +220,19 @@ module SyntaxTree
 
       def initialize(opening_tag:, keyword:, content:, closing_tag:, location:)
         @opening_tag = opening_tag
-        @keyword = keyword
-        @content = ErbContent.new(value: content.map(&:value).join) if content
+        # prune whitespace from keyword
+        @keyword =
+          if keyword
+            Token.new(
+              type: keyword.type,
+              value: keyword.value.strip,
+              location: keyword.location
+            )
+          end
+        # Set content to nil if it is empty
+        content ||= []
+        content = content.map(&:value).join if content.is_a?(Array)
+        @content = ErbContent.new(value: content) unless content.strip.empty?
         @closing_tag = closing_tag
         @location = location
       end

--- a/lib/syntax_tree/erb/pretty_print.rb
+++ b/lib/syntax_tree/erb/pretty_print.rb
@@ -108,12 +108,12 @@ module SyntaxTree
       end
 
       def visit_erb_end(node)
-        q.text("erb_end")
+        q.pp("erb_end")
       end
 
       # Visit an ErbContent node.
       def visit_erb_content(node)
-        q.text(node.value)
+        q.pp(node.value)
       end
 
       # Visit an Attribute node.
@@ -132,7 +132,7 @@ module SyntaxTree
       end
 
       def visit_erb_close(node)
-        visit_node("erb_close", node)
+        visit(node.closing)
       end
 
       def visit_erb_do_close(node)

--- a/test/fixture/erb_syntax_formatted.html.erb
+++ b/test/fixture/erb_syntax_formatted.html.erb
@@ -36,3 +36,8 @@
       end
     )
 ) %>
+
+<%
+  assign_b ||= "b"
+  assign_c ||= "c"
+%>

--- a/test/fixture/erb_syntax_unformatted.html.erb
+++ b/test/fixture/erb_syntax_unformatted.html.erb
@@ -35,3 +35,8 @@
       end
     )
 ) %>
+
+<%
+  assign_b ||= "b"
+  assign_c ||= "c"
+%>


### PR DESCRIPTION
```
<%
  a = 1
  b = 5
%>
```
this would be concatenated to one line before.

- Had to change all indentation of multiline ERB-tags to fix it.
