### PR TITLE
0.9.4: Format empty HTML-tags as a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.9.4] - 2023-07-01
+
+- Inline even more empty HTML-tags
+
+```diff
+<three-word-component
+  :attribute1
+  :attribute2
+  :attribute3="value"
+->
+-</three-word-component>
++></three-word-component>
+```
+
 ## [0.9.3] - 2023-06-30
 
 - Print empty html-tags on one line if possible

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    w_syntax_tree-erb (0.9.3)
+    w_syntax_tree-erb (0.9.4)
       prettier_print (>= 1.2.0)
       syntax_tree (>= 6.1.1)
 

--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -51,7 +51,10 @@ module SyntaxTree
       def visit_html(node)
         # Make sure to group the tags together if there is no child nodes.
         if node.elements.size == 0
-          q.group { visit_block(node) }
+          q.group do
+            visit(node.opening)
+            visit(node.closing)
+          end
         else
           visit_block(node)
         end

--- a/lib/syntax_tree/erb/version.rb
+++ b/lib/syntax_tree/erb/version.rb
@@ -2,6 +2,6 @@
 
 module SyntaxTree
   module ERB
-    VERSION = "0.9.3"
+    VERSION = "0.9.4"
   end
 end

--- a/test/fixture/javascript_frameworks_formatted.html.erb
+++ b/test/fixture/javascript_frameworks_formatted.html.erb
@@ -6,8 +6,7 @@
     boolean
     :value="['a', 'b']"
     :long-variable-name="data.item.javascript.code"
-  >
-  </card-header>
+  ></card-header>
 
   <card-body :content="<%= @content %>" @click="doThis">
     <template #button-content>
@@ -15,6 +14,11 @@
     </template>
   </card-body>
 </div>
+
+<three-word-component
+  :allowed-words="['first', 'second', 'third', 'fourth']"
+  :disallowed-words="['fifth', 'sixth']"
+></three-word-component>
 
 <!-- Alpine -->
 <div

--- a/test/fixture/javascript_frameworks_unformatted.html.erb
+++ b/test/fixture/javascript_frameworks_unformatted.html.erb
@@ -3,5 +3,8 @@
 
 <card-body :content="<%= @content %>" @click="doThis"><template #button-content>Hello</template></card-body></div>
 
+<three-word-component :allowed-words="['first', 'second', 'third', 'fourth']" :disallowed-words="['fifth', 'sixth']">
+</three-word-component>
+
 <!-- Alpine --><div x-data="{open: false}" class="absolute bottom-0" x-transition:enter="transition ease-out" x-transition:leave="transition ease-in">
 <button @click="open = true">Expand</button><span x-show="open"><h1>Hello</h1></span></div>


### PR DESCRIPTION
```diff
<three-word-component
  :attribute1
  :attribute2
  :attribute3="value"
->
-</three-word-component>
+></three-word-component>
```
