### PR TITLE
v0.9.5 - Fixes formatting of ruby comment in ERB-tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.9.5] - 2023-07-02
+
+- Fixes ruby comment in ERB-tag included VoidStatement
+  Example:
+
+```erb
+<% # this is a comment %>
+```
+
+Output:
+
+```diff
+-<%
+-
+-  # this is a comment
+-%>
++<% # this is a comment %>
+```
+
+- Updates versions in Bundler
+
 ## [0.9.4] - 2023-07-01
 
 - Inline even more empty HTML-tags

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    w_syntax_tree-erb (0.9.4)
+    w_syntax_tree-erb (0.9.5)
       prettier_print (~> 1.2, >= 1.2.0)
       syntax_tree (~> 6.1, >= 6.1.1)
 

--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -118,18 +118,19 @@ module SyntaxTree
         if node.value.is_a?(String)
           output_rows(node.value.split("\n"))
         else
-          child_nodes = node.value&.statements&.child_nodes || []
+          nodes = node.value&.statements&.child_nodes || []
+          nodes = nodes.reject { |node| node.is_a?(SyntaxTree::VoidStmt) }
 
-          if child_nodes.size == 1
+          if nodes.size == 1
             q.text(" ")
-            q.seplist(child_nodes, -> { q.breakable("") }) do |child_node|
+            q.seplist(nodes, -> { q.breakable("") }) do |child_node|
               format_statement(child_node)
             end
             q.text(" ")
-          elsif child_nodes.size > 1
+          elsif nodes.size > 1
             q.indent do
               q.breakable("")
-              q.seplist(child_nodes, -> { q.breakable("") }) do |child_node|
+              q.seplist(nodes, -> { q.breakable("") }) do |child_node|
                 format_statement(child_node)
               end
             end

--- a/lib/syntax_tree/erb/version.rb
+++ b/lib/syntax_tree/erb/version.rb
@@ -2,6 +2,6 @@
 
 module SyntaxTree
   module ERB
-    VERSION = "0.9.4"
+    VERSION = "0.9.5"
   end
 end

--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -62,6 +62,15 @@ module SyntaxTree
       assert_equal(source, formatted_twice)
     end
 
+    def test_erb_only_comment
+      source = "<% # This should be written on one line %>\n"
+      formatted_once = ERB.format(source)
+      formatted_twice = ERB.format(formatted_once)
+
+      assert_equal(source, formatted_once)
+      assert_equal(source, formatted_twice)
+    end
+
     def test_erb_ternary_as_argument_without_parentheses
       source =
         "<%=     f.submit f.object.id.present?     ? t('buttons.titles.save'):t('buttons.titles.create')   %>"

--- a/test/fixture/erb_syntax_formatted.html.erb
+++ b/test/fixture/erb_syntax_formatted.html.erb
@@ -2,6 +2,7 @@
 <%# This is an ERB-comment https://stackoverflow.com/a/25626629 this answer describes ERB and erubis syntax%>
 <%== rails_raw_output %>
 <%- "this only works in ERB not erubis" %>
+<% # This should be written on one line %>
 
 <% if this -%>
   <%= form.submit -%>

--- a/test/fixture/erb_syntax_unformatted.html.erb
+++ b/test/fixture/erb_syntax_unformatted.html.erb
@@ -2,6 +2,7 @@
 <%# This is an ERB-comment https://stackoverflow.com/a/25626629 this answer describes ERB and erubis syntax%>
 <%== rails_raw_output%>
 <%-"this only works in ERB not erubis"%>
+<% # This should be written on one line %>
 
 <% if this -%>
   <%= form.submit -%>


### PR DESCRIPTION
```erb
<% # this is a comment %>
```

Output:
```diff
-<%
-
-  # this is a comment
-%>
+<% # this is a comment %>
```