### PR TITLE
Refactor line breaks and whitespace

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "ruby_lsp",
+      "name": "Debug file",
+      "request": "launch",
+      "program": "ruby ${file}"
+    },
+    {
+      "type": "ruby_lsp",
+      "name": "Debug test",
+      "request": "launch",
+      "program": "ruby -Itest ${relativeFile}"
+    },
+    {
+      "type": "ruby_lsp",
+      "name": "Debug attach",
+      "request": "attach"
+    }
+  ]
+}

--- a/lib/syntax_tree/erb/pretty_print.rb
+++ b/lib/syntax_tree/erb/pretty_print.rb
@@ -108,7 +108,7 @@ module SyntaxTree
       end
 
       def visit_erb_end(node)
-        q.pp("erb_end")
+        q.pp("(erb_end)")
       end
 
       # Visit an ErbContent node.
@@ -131,6 +131,10 @@ module SyntaxTree
         visit_node("char_data", node)
       end
 
+      def visit_new_line(node)
+        node.count > 1 ? q.text("(new_line blank)") : q.text("(new_line)")
+      end
+
       def visit_erb_close(node)
         visit(node.closing)
       end
@@ -146,6 +150,10 @@ module SyntaxTree
 
       def visit_html_comment(node)
         visit_node("html_comment", node)
+      end
+
+      def visit_erb_comment(node)
+        visit_node("erb_comment", node)
       end
 
       private

--- a/test/fixture/block_formatted.html.erb
+++ b/test/fixture/block_formatted.html.erb
@@ -11,9 +11,7 @@
 <% end %>
 
 <%= link_to(dont_replace, what_to_do, class: "do |what,bad|") do |hello| %>
-  <span>
-    Should allow to use the word do in the code
-  </span>
+  <span>Should allow to use the word do in the code</span>
 <% end %>
 
 <%= this_is_not_a_do_block_do %>

--- a/test/fixture/erb_syntax_formatted.html.erb
+++ b/test/fixture/erb_syntax_formatted.html.erb
@@ -21,9 +21,7 @@
 <%- end %>
 
 <%= link_to(link, text) do -%>
-  <h1>
-    Cool
-  </h1>
+  <h1>Cool</h1>
 <%- end %>
 
 <%= t(

--- a/test/fixture/if_statements_formatted.html.erb
+++ b/test/fixture/if_statements_formatted.html.erb
@@ -1,20 +1,12 @@
 <% if this %>
-  <h1>
-    that
-  </h1>
+  <h1>that</h1>
 <% elsif that %>
-  <h2>
-    this
-  </h2>
+  <h2>this</h2>
   <% if nested_this %>
-    <h1>
-      this
-    </h1>
+    <h1>this</h1>
   <% end %>
 <% else %>
-  <h2>
-    else
-  </h2>
+  <h2>else</h2>
 <% end %>
 <%= what if this %>
 <h1>

--- a/test/fixture/javascript_frameworks_formatted.html.erb
+++ b/test/fixture/javascript_frameworks_formatted.html.erb
@@ -9,9 +9,7 @@
   ></card-header>
 
   <card-body :content="<%= @content %>" @click="doThis">
-    <template #button-content>
-      Hello
-    </template>
+    <template #button-content>Hello</template>
   </card-body>
 </div>
 
@@ -27,12 +25,8 @@
   x-transition:enter="transition ease-out"
   x-transition:leave="transition ease-in"
 >
-  <button @click="open = true">
-    Expand
-  </button>
+  <button @click="open = true">Expand</button>
   <span x-show="open">
-    <h1>
-      Hello
-    </h1>
+    <h1>Hello</h1>
   </span>
 </div>

--- a/test/fixture/layout_formatted.html.erb
+++ b/test/fixture/layout_formatted.html.erb
@@ -10,9 +10,7 @@
       href="https://fonts.googleapis.com/css?family=Inter:100,200,300,400,500,600,700,800,900&display=swap"
       rel="stylesheet"
     />
-    <title>
-      <%= full_title(t("general.title"), yield(:title)) %>
-    </title>
+    <title><%= full_title(t("general.title"), yield(:title)) %></title>
     <%= stylesheet_link_tag(
       "application",
       media: "all",
@@ -41,9 +39,7 @@
         </main>
       </div>
 
-      <footer>
-        <%= render("footer") %>
-      </footer>
+      <footer><%= render("footer") %></footer>
     </div>
   </body>
 </html>

--- a/test/fixture/nested_html_formatted.html.erb
+++ b/test/fixture/nested_html_formatted.html.erb
@@ -1,7 +1,5 @@
 <div class="card">
   <span class="small">
-    <%= t(".title") + " " + t(".description") + " " + t(".pretty_long") %>
-    'This is a single quote'
-  </span>
-  "This is a double quote"
+    <%= t(".title") + " " + t(".description") + " " + t(".pretty_long") %>'This is a single quote'
+  </span>"This is a double quote"
 </div>

--- a/test/formatting_test.rb
+++ b/test/formatting_test.rb
@@ -38,9 +38,11 @@ module SyntaxTree
       directory = File.expand_path("fixture", __dir__)
       unformatted_file = File.join(directory, "#{name}_unformatted.html.erb")
       formatted_file = File.join(directory, "#{name}_formatted.html.erb")
+      source = SyntaxTree::ERB.read(unformatted_file)
 
+      parsed = SyntaxTree::ERB.parse(source)
       expected = SyntaxTree::ERB.read(formatted_file)
-      formatted = SyntaxTree::ERB.format(SyntaxTree::ERB.read(unformatted_file))
+      formatted = SyntaxTree::ERB.format(source)
 
       if (expected != formatted)
         puts("Failed to format #{name}, see ./tmp/#{name}_failed.html.erb")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,3 +7,28 @@ $:.unshift File.expand_path("../lib", __dir__)
 require "syntax_tree/erb"
 
 require "minitest/autorun"
+
+class TestCase < Minitest::Test
+  def assert_formatting(source, expected)
+    parsed = SyntaxTree::ERB.parse(source)
+    formatted = SyntaxTree::ERB.format(source)
+
+    if (expected != formatted)
+      binding.irb if debug
+    end
+
+    assert_equal(formatted, expected, "Failed first")
+
+    formatted_twice = SyntaxTree::ERB.format(formatted)
+
+    if (expected != formatted_twice)
+      binding.irb if debug
+    end
+
+    assert_equal(formatted_twice, expected, "Failed second")
+
+    # Check that pretty_print works
+    output = SyntaxTree::ERB.parse(expected).pretty_inspect
+    refute_predicate(output, :empty?)
+  end
+end


### PR DESCRIPTION
Instead of trying to remove line-breaks in certain situations, instead we only add
line-breaks were we are "sure" they are needed.

This should allow us to do:

```html
Hello <%= user.name %>,
```

or

```html
*<%= payment_source.last_digits %>
<%= payment_source.month %>/<%= payment_source.year %>
```
