### PR TITLE
Handles doctype more freely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.10.1] - 2023-08-20
+
+### Added
+
+- Allow `DOCTYPE` to be after other tags, to work with e.g. ERB-tags on first line.
+
 ## [0.10.0] - 2023-08-20
 
 - Changes how whitespace and newlines are handled.
@@ -70,7 +76,8 @@ Output:
 - Can format a lot of .html.erb-syntax and works as a plugin to syntax_tree.
 - This is still early and there are a lot of different weird syntaxes out there.
 
-[unreleased]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.0...HEAD
+[unreleased]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.9.5...v0.10.0
 [0.9.5]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.9.3...v0.9.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    w_syntax_tree-erb (0.10.0)
+    w_syntax_tree-erb (0.10.1)
       prettier_print (~> 1.2, >= 1.2.0)
       syntax_tree (~> 6.1, >= 6.1.1)
 

--- a/lib/syntax_tree/erb/version.rb
+++ b/lib/syntax_tree/erb/version.rb
@@ -2,6 +2,6 @@
 
 module SyntaxTree
   module ERB
-    VERSION = "0.10.0"
+    VERSION = "0.10.1"
   end
 end

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -34,6 +34,19 @@ module SyntaxTree
 
       parsed = ERB.parse("<!doctype html>")
       assert_instance_of(SyntaxTree::ERB::Doctype, parsed.elements.first)
+
+      # Allow doctype to not be the first element
+      parsed = ERB.parse("<% theme = \"general\" %> <!DOCTYPE html>")
+      assert_equal(2, parsed.elements.size)
+      assert_equal(
+        [SyntaxTree::ERB::ErbNode, SyntaxTree::ERB::Doctype],
+        parsed.elements.map(&:class)
+      )
+
+      # Do not allow multiple doctype elements
+      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+        ERB.parse("<!DOCTYPE html>\n<!DOCTYPE html>\n")
+      end
     end
 
     def test_html_comment


### PR DESCRIPTION
- Support ERB-tags before DOCTYPE.
- Parse error on multiple DOCTYPE elements.
