### PR TITLE
Handle do-arguments in ERB-tags and release 0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+## [0.10.5] - 2023-09-03
+
 - Handle ERB-tags inside HTML-tags, like `<div <%= "class='foo'" %>>`
 - Handles indentation for multiline ERB-comment
+- Handles spaces between do-arguments and ERB-tags
 
 ## [0.10.4] - 2023-08-28
 
@@ -106,7 +109,8 @@ Output:
 - Can format a lot of .html.erb-syntax and works as a plugin to syntax_tree.
 - This is still early and there are a lot of different weird syntaxes out there.
 
-[unreleased]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.4...HEAD
+[unreleased]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.5...HEAD
+[0.10.5]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.4...v0.10.5
 [0.10.4]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/davidwessman/syntax_tree-erb/compare/v0.10.1...v0.10.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    w_syntax_tree-erb (0.10.4)
+    w_syntax_tree-erb (0.10.5)
       prettier_print (~> 1.2, >= 1.2.0)
       syntax_tree (~> 6.1, >= 6.1.1)
 

--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -121,7 +121,10 @@ module SyntaxTree
       end
 
       def visit_erb_do_close(node)
-        visit(node.closing)
+        closing = node.closing.value.end_with?("-%>") ? "-%>" : "%>"
+        q.text(node.closing.value.gsub(closing, "").rstrip)
+        q.text(" ")
+        q.text(closing)
       end
 
       def visit_erb_close(node)

--- a/lib/syntax_tree/erb/version.rb
+++ b/lib/syntax_tree/erb/version.rb
@@ -2,6 +2,6 @@
 
 module SyntaxTree
   module ERB
-    VERSION = "0.10.4"
+    VERSION = "0.10.5"
   end
 end

--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -139,6 +139,14 @@ module SyntaxTree
       assert_formatting(source, expected)
     end
 
+    def test_erb_block_do_arguments
+      source = "<%= link_to(url) do |link, other_arg|%>Whaaaaaaat<% end %>"
+      expected =
+        "<%= link_to(url) do |link, other_arg| %>\n  Whaaaaaaat\n<% end %>\n"
+
+      assert_formatting(source, expected)
+    end
+
     def test_erb_newline
       source = "<%= what if this %>\n<h1>hej</h1>"
       expected = "<%= what if this %>\n<h1>hej</h1>\n"


### PR DESCRIPTION
- Handles spaces after do-arguments in ERB-tags
- Release 0.10.5
