### PR TITLE
Allow html void tags

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ puts failures
 
 ## Development
 
+Install `husky`:
+
+```sh
+npm i -g husky
+```
+
 Setup linting:
 
 ```sh

--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -203,6 +203,10 @@ module SyntaxTree
             q.text(" ")
           end
 
+          # If element is a valid void element, but not currently self-closing
+          # format to be self-closing
+          q.text(" /") if node.is_void_element? and node.closing.value == ">"
+
           visit(node.closing)
         end
       end

--- a/lib/syntax_tree/erb/nodes.rb
+++ b/lib/syntax_tree/erb/nodes.rb
@@ -185,6 +185,25 @@ module SyntaxTree
     # potentially contain an opening tag that self-closes, in which case the
     # content and closing tag will be nil.
     class HtmlNode < Block
+      # These elements do not require a closing tag
+      # https://developer.mozilla.org/en-US/docs/Glossary/Void_element
+      HTML_VOID_ELEMENTS = %w[
+        area
+        base
+        br
+        col
+        embed
+        hr
+        img
+        input
+        link
+        meta
+        param
+        source
+        track
+        wbr
+      ]
+
       # The opening tag of an element. It contains the opening character (<),
       # the name of the element, any optional attributes, and the closing
       # token (either > or />).
@@ -212,6 +231,10 @@ module SyntaxTree
 
         def child_nodes
           [opening, name, *attributes, closing]
+        end
+
+        def is_void_element?
+          HTML_VOID_ELEMENTS.include?(name.value)
         end
 
         alias deconstruct child_nodes
@@ -251,6 +274,10 @@ module SyntaxTree
         def deconstruct_keys(keys)
           super.merge(opening: opening, name: name, closing: closing)
         end
+      end
+
+      def is_void_element?
+        false
       end
 
       def without_new_line

--- a/lib/syntax_tree/erb/parser.rb
+++ b/lib/syntax_tree/erb/parser.rb
@@ -419,7 +419,11 @@ module SyntaxTree
       def parse_html_element
         opening = parse_html_opening_tag
 
-        if opening.closing.value == ">"
+        if opening.closing.value == "/>"
+          HtmlNode.new(opening: opening, location: opening.location)
+        elsif opening.is_void_element?
+          HtmlNode.new(opening: opening, location: opening.location)
+        else
           elements = many { parse_any_tag }
           closing = maybe { parse_html_closing }
 
@@ -443,8 +447,6 @@ module SyntaxTree
             closing: closing,
             location: opening.location.to(closing.location)
           )
-        else
-          HtmlNode.new(opening: opening, location: opening.location)
         end
       end
 

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -205,5 +205,12 @@ module SyntaxTree
 
       assert_formatting(source, expected)
     end
+
+    def test_self_closing_for_void_elements
+      source =  "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" >"
+      expected = "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />\n"
+
+      assert_formatting(source, expected)
+    end
   end
 end


### PR DESCRIPTION
Hello!

I've been trying to figure out how to get `prettier` to format my `.html.erb` files. It seems like https://github.com/adamzapasnik/prettier-plugin-erb is a dead project. But this project you've been working on may be the best way to go.

I have a [branch](https://github.com/rdimartino/plugin-ruby/tree/erb) of `prettier-plugin-ruby` that adds this gem and it's working great. (I also have eyes on [this issue](https://github.com/ruby-syntax-tree/syntax_tree/issues/383) which I think would be a great step toward ultimately getting this included as part of the plugin for ruby)

This fix came from trying to use this gem to format my `.html.erb` files. I was running into syntax errors for void elements that were not explicitly self-closing.

Thanks!