### PR TITLE
Adds support for default error reporting

### DIFF
--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -12,19 +12,19 @@ module SyntaxTree
     end
 
     def test_missing_erb_end_tag
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+      assert_raises(SyntaxTree::Parser::ParseError) do
         ERB.parse("<% if no_end_tag %>")
       end
     end
 
     def test_missing_erb_block_end_tag
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+      assert_raises(SyntaxTree::Parser::ParseError) do
         ERB.parse("<% no_end_tag do %>")
       end
     end
 
     def test_missing_erb_case_end_tag
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+      assert_raises(SyntaxTree::Parser::ParseError) do
         ERB.parse("<% case variabel %>\n<% when 1>\n  Hello\n")
       end
     end
@@ -33,6 +33,23 @@ module SyntaxTree
       parsed = ERB.parse("<% \"Påäööööö\" %>")
       assert_equal(1, parsed.elements.size)
       assert_instance_of(SyntaxTree::ERB::ErbNode, parsed.elements.first)
+    end
+
+    def test_erb_errors
+      example = <<-HTML
+<ul>
+<% if @items.each do |i|%>
+<li><%= i %></li>
+<% end.blank? %>
+<li>No items</li>
+<% end %>
+</ul>
+HTML
+      ERB.parse(example)
+    rescue SyntaxTree::Parser::ParseError => error
+      assert_equal(2, error.lineno)
+      assert_equal(0, error.column)
+      assert_match(/Could not parse ERB-tag/, error.message)
     end
 
     def test_if_and_end_in_same_output_tag_short

--- a/test/html_test.rb
+++ b/test/html_test.rb
@@ -5,25 +5,25 @@ require "test_helper"
 module SyntaxTree
   class HtmlTest < TestCase
     def test_html_missing_end_tag
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+      assert_raises(SyntaxTree::Parser::ParseError) do
         ERB.parse("<h1>Hello World")
       end
     end
 
     def test_html_incorrect_end_tag
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+      assert_raises(SyntaxTree::Parser::ParseError) do
         ERB.parse("<h1>Hello World</h2>")
       end
     end
 
     def test_html_unmatched_double_quote
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+      assert_raises(SyntaxTree::Parser::ParseError) do
         ERB.parse("<div class=\"card-\"\">Hello World</div>")
       end
     end
 
     def test_html_unmatched_single_quote
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+      assert_raises(SyntaxTree::Parser::ParseError) do
         ERB.parse("<div class='card-''>Hello World</div>")
       end
     end
@@ -49,7 +49,7 @@ module SyntaxTree
       )
 
       # Do not allow multiple doctype elements
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
+      assert_raises(SyntaxTree::Parser::ParseError) do
         ERB.parse("<!DOCTYPE html>\n<!DOCTYPE html>\n")
       end
     end
@@ -78,15 +78,9 @@ module SyntaxTree
     end
 
     def test_html_tag_names
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
-        ERB.parse("<@br />")
-      end
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
-        ERB.parse("<:br />")
-      end
-      assert_raises(SyntaxTree::ERB::Parser::ParseError) do
-        ERB.parse("<#br />")
-      end
+      assert_raises(SyntaxTree::Parser::ParseError) { ERB.parse("<@br />") }
+      assert_raises(SyntaxTree::Parser::ParseError) { ERB.parse("<:br />") }
+      assert_raises(SyntaxTree::Parser::ParseError) { ERB.parse("<#br />") }
     end
 
     def test_html_attribute_without_quotes
@@ -207,8 +201,10 @@ module SyntaxTree
     end
 
     def test_self_closing_for_void_elements
-      source =  "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" >"
-      expected = "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />\n"
+      source =
+        "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" >"
+      expected =
+        "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\" />\n"
 
       assert_formatting(source, expected)
     end


### PR DESCRIPTION
- By raising SyntaxTree::Parser::ParseError with default arguments
  it returns much nicer error messages.
