### PR TITLE
Support for more syntax and better multiline ERB formatting

### DIFF
--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -31,22 +31,23 @@ module SyntaxTree
 
       # Dependent block is one that follows after a "main one", e.g. <% else %>
       def visit_block(node, dependent: false)
-        process = proc do
-          visit(node.opening)
+        process =
+          proc do
+            visit(node.opening)
 
-          breakable = breakable_inside(node)
-          if node.elements.any?
-            q.indent do
+            breakable = breakable_inside(node)
+            if node.elements.any?
+              q.indent do
+                q.breakable("") if breakable
+                handle_child_nodes(node.elements)
+              end
+            end
+
+            if node.closing
               q.breakable("") if breakable
-              handle_child_nodes(node.elements)
+              visit(node.closing)
             end
           end
-
-          if node.closing
-            q.breakable("") if breakable
-            visit(node.closing)
-          end
-        end
 
         if dependent
           process.call
@@ -181,7 +182,8 @@ module SyntaxTree
         q.indent do
           q.breakable
           q.seplist(nodes, -> { q.breakable(force: true) }) do |child_node|
-            code = format_statement_with_keyword_prefix(child_node, keyword: keyword)
+            code =
+              format_statement_with_keyword_prefix(child_node, keyword: keyword)
             output_rows(code.split("\n"))
             # Pass the keyword only to the first child node
             keyword = nil
@@ -423,7 +425,8 @@ module SyntaxTree
         when "case"
           statement =
             SyntaxTree::Case.new(
-              keyword: SyntaxTree::Kw.new(value: "case", location: keyword.location),
+              keyword:
+                SyntaxTree::Kw.new(value: "case", location: keyword.location),
               value: statement,
               consequent: void_body,
               location: keyword.location

--- a/lib/syntax_tree/erb/format.rb
+++ b/lib/syntax_tree/erb/format.rb
@@ -7,6 +7,7 @@ module SyntaxTree
 
       def initialize(q)
         @q = q
+        @inside_html_attributes = false
       end
 
       # Visit a Token node.
@@ -28,20 +29,32 @@ module SyntaxTree
         q.breakable(force: true)
       end
 
-      def visit_block(node)
-        visit(node.opening)
+      # Dependent block is one that follows after a "main one", e.g. <% else %>
+      def visit_block(node, dependent: false)
+        process = proc do
+          visit(node.opening)
 
-        breakable = breakable_inside(node)
-        if node.elements.any?
-          q.indent do
-            q.breakable if breakable
-            handle_child_nodes(node.elements)
+          breakable = breakable_inside(node)
+          if node.elements.any?
+            q.indent do
+              q.breakable("") if breakable
+              handle_child_nodes(node.elements)
+            end
+          end
+
+          if node.closing
+            q.breakable("") if breakable
+            visit(node.closing)
           end
         end
 
-        if node.closing
-          q.breakable("") if breakable
-          visit(node.closing)
+        if dependent
+          process.call
+        else
+          q.group do
+            q.break_parent unless @inside_html_attributes
+            process.call
+          end
         end
       end
 
@@ -92,11 +105,11 @@ module SyntaxTree
       end
 
       def visit_erb_elsif(node)
-        visit_block(node)
+        visit_block(node, dependent: true)
       end
 
       def visit_erb_else(node)
-        visit_block(node)
+        visit_block(node, dependent: true)
       end
 
       def visit_erb_case(node)
@@ -104,27 +117,42 @@ module SyntaxTree
       end
 
       def visit_erb_case_when(node)
-        visit_block(node)
+        visit_block(node, dependent: true)
       end
 
       # Visit an ErbNode node.
       def visit_erb(node)
         visit(node.opening_tag)
 
-        if node.keyword
-          q.text(" ")
-          visit(node.keyword)
+        q.group do
+          if !node.keyword && node.content.blank?
+            q.text(" ")
+          elsif node.keyword && node.content.blank?
+            q.text(" ")
+            visit(node.keyword)
+            q.text(" ")
+          else
+            visit_erb_content(node.content, keyword: node.keyword)
+            q.breakable unless node.closing_tag.is_a?(ErbDoClose)
+          end
         end
-
-        node.content.blank? ? q.text(" ") : visit(node.content)
 
         visit(node.closing_tag)
       end
 
       def visit_erb_do_close(node)
         closing = node.closing.value.end_with?("-%>") ? "-%>" : "%>"
-        q.text(node.closing.value.gsub(closing, "").rstrip)
-        q.text(" ")
+        # Append the "do" at the end of Ruby code (within the same group)
+        last_erb_content_group = q.current_group.contents.last
+        last_erb_content_indent = last_erb_content_group.contents.last
+        q.with_target(last_erb_content_indent.contents) do
+          q.text(" ")
+          q.text(node.closing.value.gsub(closing, "").rstrip)
+        end
+
+        # Add a breakable space after the indent, but within the same group
+        q.with_target(last_erb_content_group.contents) { q.breakable }
+
         q.text(closing)
       end
 
@@ -145,55 +173,25 @@ module SyntaxTree
         visit(node.closing_tag)
       end
 
-      def visit_erb_content(node)
+      def visit_erb_content(node, keyword: nil)
         # Reject all VoidStmt to avoid empty lines
-        nodes =
-          (node.value&.statements&.child_nodes || []).reject do |node|
-            node.is_a?(SyntaxTree::VoidStmt)
-          end
+        nodes = child_nodes_without_void_statements(node)
+        return if nodes.empty?
 
-        if nodes.size == 1
-          q.text(" ")
-          format_statement(nodes.first)
-          q.text(" ")
-        elsif nodes.size > 1
-          q.indent do
-            q.breakable("")
-            q.seplist(nodes, -> { q.breakable("") }) do |child_node|
-              format_statement(child_node)
-            end
-          end
-
+        q.indent do
           q.breakable
-        end
-      end
-
-      def format_statement(statement)
-        formatter =
-          SyntaxTree::Formatter.new("", [], SyntaxTree::ERB::MAX_WIDTH)
-
-        formatter.format(statement)
-        formatter.flush
-
-        formatted =
-          formatter.output.join.gsub(
-            SyntaxTree::ERB::ErbYield::PLACEHOLDER,
-            "yield"
-          )
-
-        output_rows(formatted.split("\n"))
-      end
-
-      def output_rows(rows)
-        if rows.size > 1
-          q.seplist(rows, -> { q.breakable("") }) { |row| q.text(row) }
-        elsif rows.size == 1
-          q.text(rows.first)
+          q.seplist(nodes, -> { q.breakable(force: true) }) do |child_node|
+            code = format_statement_with_keyword_prefix(child_node, keyword: keyword)
+            output_rows(code.split("\n"))
+            # Pass the keyword only to the first child node
+            keyword = nil
+          end
         end
       end
 
       # Visit an HtmlNode::OpeningTag node.
       def visit_opening_tag(node)
+        @inside_html_attributes = true
         q.group do
           visit(node.opening)
           visit(node.name)
@@ -219,6 +217,7 @@ module SyntaxTree
 
           visit(node.closing)
         end
+        @inside_html_attributes = false
       end
 
       # Visit an HtmlNode::ClosingTag node.
@@ -382,6 +381,107 @@ module SyntaxTree
       def node_should_group(node)
         node.is_a?(SyntaxTree::ERB::CharData) ||
           node.is_a?(SyntaxTree::ERB::ErbNode)
+      end
+
+      def child_nodes_without_void_statements(node)
+        (node.value&.statements&.child_nodes || []).reject do |node|
+          node.is_a?(SyntaxTree::VoidStmt)
+        end
+      end
+
+      def format_statement_with_keyword_prefix(statement, keyword: nil)
+        case keyword&.value
+        when nil
+          format_statement(statement)
+        when "if"
+          statement =
+            SyntaxTree::IfNode.new(
+              predicate: statement,
+              statements: void_body,
+              consequent: nil,
+              location: keyword.location
+            )
+          format_statement(statement).delete_suffix("\nend")
+        when "unless"
+          statement =
+            SyntaxTree::UnlessNode.new(
+              predicate: statement,
+              statements: void_body,
+              consequent: nil,
+              location: keyword.location
+            )
+          format_statement(statement).delete_suffix("\nend")
+        when "elsif"
+          statement =
+            SyntaxTree::Elsif.new(
+              predicate: statement,
+              statements: void_body,
+              consequent: nil,
+              location: keyword.location
+            )
+          format_statement(statement).delete_suffix("\nend")
+        when "case"
+          statement =
+            SyntaxTree::Case.new(
+              keyword: SyntaxTree::Kw.new(value: "case", location: keyword.location),
+              value: statement,
+              consequent: void_body,
+              location: keyword.location
+            )
+          format_statement(statement).delete_suffix("\nend")
+        when "when"
+          statement =
+            SyntaxTree::When.new(
+              arguments: statement.contents,
+              statements: void_body,
+              consequent: nil,
+              location: keyword.location
+            )
+          format_statement(statement).delete_suffix("\nend")
+        else
+          q.text(keyword.value)
+          q.breakable
+          format_statement(statement)
+        end
+      end
+
+      def format_statement(statement)
+        formatter =
+          SyntaxTree::Formatter.new("", [], SyntaxTree::ERB::MAX_WIDTH)
+
+        formatter.format(statement)
+        formatter.flush
+
+        formatter.output.join.gsub(
+          SyntaxTree::ERB::ErbYield::PLACEHOLDER,
+          "yield"
+        )
+      end
+
+      def output_rows(rows)
+        if rows.size > 1
+          q.seplist(rows, -> { q.breakable(force: true) }) { |row| q.text(row) }
+        elsif rows.size == 1
+          q.text(rows.first)
+        end
+      end
+
+      def fake_location
+        Location.new(
+          start_line: 0,
+          start_char: 0,
+          start_column: 0,
+          end_line: 0,
+          end_char: 0,
+          end_column: 0
+        )
+      end
+
+      def void_body
+        SyntaxTree::Statements.new(
+          body: [SyntaxTree::VoidStmt.new(location: fake_location)],
+          location: fake_location
+        )
       end
     end
   end

--- a/lib/syntax_tree/erb/nodes.rb
+++ b/lib/syntax_tree/erb/nodes.rb
@@ -322,10 +322,15 @@ module SyntaxTree
         if content.is_a?(ErbContent)
           content
         else
-          # Set content to nil if it is empty
           content ||= []
 
-          ErbContent.new(value: content)
+          if !content.empty? && keyword&.value == "when"
+            # "when" accepts multiple comma-separated arguments, so let's try
+            # to make them parsable.
+            ErbContent.new(value: ["[", *content, "]"])
+          else
+            ErbContent.new(value: content)
+          end
         end
       rescue SyntaxTree::Parser::ParseError
         # Try to add the keyword to see if it parses

--- a/lib/syntax_tree/erb/pretty_print.rb
+++ b/lib/syntax_tree/erb/pretty_print.rb
@@ -51,7 +51,7 @@ module SyntaxTree
             end
             if node.content
               q.breakable
-              q.text("content")
+              visit(node.content)
             end
 
             q.breakable
@@ -67,6 +67,7 @@ module SyntaxTree
           q.text("(erb_block")
           q.nest(2) do
             q.breakable
+            visit(node.opening)
             q.seplist(node.elements) { |child_node| visit(child_node) }
           end
           q.breakable

--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -111,8 +111,19 @@ module SyntaxTree
     def test_if_and_end_in_same_tag
       source =
         "Hello\n<% if true then this elsif false then that else maybe end %>\n<h1>Hey</h1>"
-      expected =
-        "Hello\n<% if true\n  this\nelsif false\n  that\nelse\n  maybe\nend %>\n<h1>Hey</h1>\n"
+      expected = <<~EXPECTED
+        Hello
+        <%
+          if true
+            this
+          elsif false
+            that
+          else
+            maybe
+          end
+        %>
+        <h1>Hey</h1>
+      EXPECTED
 
       assert_formatting(source, expected)
     end
@@ -127,8 +138,13 @@ module SyntaxTree
     def test_long_if_statement
       source =
         "<%=number_to_percentage(@reports&.first&.stability*100,precision: 1) if @reports&.first&.other&.stronger&.longer %>"
-      expected =
-        "<%= if @reports&.first&.other&.stronger&.longer\n  number_to_percentage(@reports&.first&.stability * 100, precision: 1)\nend %>\n"
+      expected = <<~EXPECTED
+        <%=
+          if @reports&.first&.other&.stronger&.longer
+            number_to_percentage(@reports&.first&.stability * 100, precision: 1)
+          end
+        %>
+      EXPECTED
 
       assert_formatting(source, expected)
     end
@@ -136,8 +152,15 @@ module SyntaxTree
     def test_erb_else_if_statement
       source =
         "<%if this%>\n  <h1>A</h1>\n<%elsif that%>\n  <h1>B</h1>\n<%else%>\n  <h1>C</h1>\n<%end%>"
-      expected =
-        "<% if this %>\n  <h1>A</h1>\n<% elsif that %>\n  <h1>B</h1>\n<% else %>\n  <h1>C</h1>\n<% end %>\n"
+      expected = <<~EXPECTED
+        <% if this %>
+          <h1>A</h1>
+        <% elsif that %>
+          <h1>B</h1>
+        <% else %>
+          <h1>C</h1>
+        <% end %>
+      EXPECTED
 
       assert_formatting(source, expected)
     end
@@ -145,8 +168,14 @@ module SyntaxTree
     def test_long_ternary
       source =
         "<%= number_to_percentage(@reports&.first&.stability * 100, precision: @reports&.first&.stability ? 'Stable' : 'Unstable') %>"
-      expected =
-        "<%= number_to_percentage(\n  @reports&.first&.stability * 100,\n  precision: @reports&.first&.stability ? \"Stable\" : \"Unstable\"\n) %>\n"
+      expected = <<~EXPECTED
+        <%=
+          number_to_percentage(
+            @reports&.first&.stability * 100,
+            precision: @reports&.first&.stability ? "Stable" : "Unstable"
+          )
+        %>
+      EXPECTED
 
       assert_formatting(source, expected)
     end
@@ -190,8 +219,13 @@ module SyntaxTree
     def test_erb_ternary_as_argument_without_parentheses
       source =
         "<%=     f.submit( f.object.id.present?     ? t('buttons.titles.save'):t('buttons.titles.create'))   %>"
-      expected =
-        "<%= f.submit(\n  f.object.id.present? ? t(\"buttons.titles.save\") : t(\"buttons.titles.create\")\n) %>\n"
+      expected = <<~EXPECTED
+        <%=
+          f.submit(
+            f.object.id.present? ? t("buttons.titles.save") : t("buttons.titles.create")
+          )
+        %>
+      EXPECTED
 
       assert_formatting(source, expected)
     end

--- a/test/erb_test.rb
+++ b/test/erb_test.rb
@@ -128,9 +128,32 @@ module SyntaxTree
       assert_formatting(source, expected)
     end
 
-    def test_erb_inside_html_tag
-      source = "<div <% if eeee then \"b\" else c end %>></div>"
-      expected = "<div <% eeee ? \"b\" : c %>></div>\n"
+    def test_erb_output_inside_html_tag
+      source = "<div <%= if eeee then \"b\" else c end %>></div>"
+      expected = "<div <%= eeee ? \"b\" : c %>></div>\n"
+
+      assert_formatting(source, expected)
+    end
+
+    def test_erb_if_inside_html_tag
+      source = "<div <% if eeee %>b<% else %><%= c %><% end %>></div>"
+      expected = "<div <% if eeee %>b<% else %><%= c %><% end %>></div>\n"
+
+      assert_formatting(source, expected)
+    end
+
+    def test_erb_output_inside_html_attribute_value
+      source = "<div class='foo <%= some_class %>'></div>"
+      expected = "<div class=\"foo <%= some_class %>\"></div>\n"
+
+      assert_formatting(source, expected)
+    end
+
+    def test_erb_if_inside_html_attribute_value
+      source =
+        "<div class='foo <% if a %>b<%    else %><%= c %><% end %>'></div>"
+      expected =
+        "<div class=\"foo <% if a %>b<% else %><%= c %><% end %>\"></div>\n"
 
       assert_formatting(source, expected)
     end

--- a/test/fixture/block_formatted.html.erb
+++ b/test/fixture/block_formatted.html.erb
@@ -4,10 +4,12 @@
     <%= form.text_field(:name, class: "form-control") %>
   </div>
 
-  <%= form.submit(
-    "Very very very very very long text",
-    class: "btn btn-primary btn btn-primary btn btn-primary btn btn-primary"
-  ) %>
+  <%=
+    form.submit(
+      "Very very very very very long text",
+      class: "btn btn-primary btn btn-primary btn btn-primary btn btn-primary"
+    )
+  %>
 <% end %>
 
 <%= link_to(dont_replace, what_to_do, class: "do |what,bad|") do |hello| %>

--- a/test/fixture/case_formatted.html.erb
+++ b/test/fixture/case_formatted.html.erb
@@ -5,6 +5,8 @@
   This is the second case.
 <% when 3 %>
   This is the third case.
+<% when 4, 5 %>
+  This is the fourth and fifth case.
 <% else %>
   This is the default case.
 <% end %>

--- a/test/fixture/case_unformatted.html.erb
+++ b/test/fixture/case_unformatted.html.erb
@@ -2,6 +2,8 @@
 This is the second case.
 <% when 3%>
                      This is the third case.
+    <% when 4, 5 %>
+  This is the fourth and fifth case.
 <% else %>
 This is the default case.
 <% end%>

--- a/test/fixture/erb_inside_html_tag_formatted.html.erb
+++ b/test/fixture/erb_inside_html_tag_formatted.html.erb
@@ -1,0 +1,4 @@
+<div class="<%= something %>"></div>
+<input <%= "disabled" if something %> />
+<input <%= something ? "disabled" : "" %> />
+<input <% if something %>disabled<% end %> />

--- a/test/fixture/erb_inside_html_tag_unformatted.html.erb
+++ b/test/fixture/erb_inside_html_tag_unformatted.html.erb
@@ -1,0 +1,10 @@
+<div
+    class="<%= something %>"
+    ></div>
+<input     <%= 'disabled' if something %>>
+<input
+  <%= something ? 'disabled' : '' %>
+/>
+<input
+  <% if something %>disabled<% end %>
+>

--- a/test/fixture/erb_syntax_formatted.html.erb
+++ b/test/fixture/erb_syntax_formatted.html.erb
@@ -29,17 +29,19 @@ Treat it as a comment
   <h1>Cool</h1>
 <%- end %>
 
-<%= t(
-  ".verified_at",
-  at:
-    (
-      if @repository.github_status_at
-        l(@repository.github_status_at, format: :long)
-      else
-        "?"
-      end
-    )
-) %>
+<%=
+  t(
+    ".verified_at",
+    at:
+      (
+        if @repository.github_status_at
+          l(@repository.github_status_at, format: :long)
+        else
+          "?"
+        end
+      )
+  )
+%>
 
 <%
   assign_b ||= "b"

--- a/test/fixture/if_statements_formatted.html.erb
+++ b/test/fixture/if_statements_formatted.html.erb
@@ -19,8 +19,12 @@
   <% end %>
 </h1>
 
-<%= if @model
-  @model.name
-else
-  t("views.more_than_80_characters_long_row.categories.shared.version.default")
-end %>
+<%=
+  if @model
+    @model.name
+  else
+    t("views.more_than_80_characters_long_row.categories.shared.version.default")
+  end
+%>
+
+<div class="<% if this %>that<% else %>something else<% end %>"></div>

--- a/test/fixture/if_statements_unformatted.html.erb
+++ b/test/fixture/if_statements_unformatted.html.erb
@@ -6,3 +6,5 @@
         <% end %></h1>
 
 <%= @model ? @model.name : t("views.more_than_80_characters_long_row.categories.shared.version.default") %>
+
+<div class="<% if this %>that<% else %>something else<% end %>"></div>

--- a/test/fixture/layout_formatted.html.erb
+++ b/test/fixture/layout_formatted.html.erb
@@ -11,16 +11,20 @@
       rel="stylesheet"
     />
     <title><%= full_title(t("general.title"), yield(:title)) %></title>
-    <%= stylesheet_link_tag(
-      "application",
-      media: "all",
-      "data-turbolinks-track": "reload"
-    ) %>
-    <%= javascript_include_tag(
-      "application",
-      "data-turbolinks-track": "reload",
-      defer: true
-    ) %>
+    <%=
+      stylesheet_link_tag(
+        "application",
+        media: "all",
+        "data-turbolinks-track": "reload"
+      )
+    %>
+    <%=
+      javascript_include_tag(
+        "application",
+        "data-turbolinks-track": "reload",
+        defer: true
+      )
+    %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= render("application/favicon") %>

--- a/test/fixture/nested_html_formatted.html.erb
+++ b/test/fixture/nested_html_formatted.html.erb
@@ -1,5 +1,7 @@
 <div class="card">
   <span class="small">
-    <%= t(".title") + " " + t(".description") + " " + t(".pretty_long") %>'This is a single quote'
+    <%=
+      t(".title") + " " + t(".description") + " " + t(".pretty_long")
+    %>'This is a single quote'
   </span>"This is a double quote"
 </div>

--- a/test/fixture/without_parens_formatted.html.erb
+++ b/test/fixture/without_parens_formatted.html.erb
@@ -1,0 +1,23 @@
+<%= this_is "short", "enough" %>
+<%
+  if condition? this_is_short
+    x
+  else
+    y
+  end
+%>
+<%
+  if condition? this_is_pretty_long,
+                so_we_probably,
+                cant_fit_all_arguments,
+                in_one_line
+%>
+  <%=
+    render "some_partial",
+           param_one: 1,
+           param_two: 2,
+           param_three: 3,
+           param_four: 4,
+           param_five: 5
+  %>
+<% end %>

--- a/test/fixture/without_parens_unformatted.html.erb
+++ b/test/fixture/without_parens_unformatted.html.erb
@@ -1,0 +1,5 @@
+<%= this_is 'short', 'enough' %>
+<% if condition? this_is_short then x else y end %>
+<% if condition? this_is_pretty_long, so_we_probably, cant_fit_all_arguments, in_one_line %>
+  <%= render 'some_partial', param_one: 1, param_two: 2, param_three: 3, param_four: 4, param_five: 5 %>
+<% end %>

--- a/test/formatting_test.rb
+++ b/test/formatting_test.rb
@@ -32,6 +32,10 @@ module SyntaxTree
       assert_formatting("layout")
     end
 
+    def test_method_calls_without_parens
+      assert_formatting("without_parens")
+    end
+
     private
 
     def assert_formatting(name)

--- a/test/formatting_test.rb
+++ b/test/formatting_test.rb
@@ -36,6 +36,10 @@ module SyntaxTree
       assert_formatting("without_parens")
     end
 
+    def test_erb_inside_html_tag
+      assert_formatting("erb_inside_html_tag")
+    end
+
     private
 
     def assert_formatting(name)


### PR DESCRIPTION
Hi,

First of all, thanks for building `syntax_tree-erb`! It was the closest to what I was looking for, so I forked it and made a few changes. I think you may agree with most (or all?) of them, so I'm letting you know what I did here.

My code is slightly hacky in places and I don't fully know what I'm doing, so do let me know if you'd like me to clean something up.

### Multiline ERB formatting

Before my change multiline ERB would be formatted more or less like this:
```erb
<%= with_brackets(
  argument1,
  argument2,
  argument3
) %>
<%= without_brackets argument1,
                 argument2,
                 argument3 %>
```
I think whether the version with brackets looks good is subjective, but I have to assume the version without brackets wasn't intended - the alignment is off by the length of `<%= ` prefix.

One way to improve it may be to use the `erb` plugin together with the [no_alignment](https://github.com/spect88/syntax_tree-no_alignment) plugin, which will give something like this:
```erb
<%= without_brackets argument1,
  argument2,
  argument3 %>
```
That still doesn't look great though.

What my branch (this PR) does is the following:
```erb
<%=
  with_brackets(
    argument1,
    argument2,
    argument3
  )
%>
<%=
  without_brackets argument1,
                   argument2,
                   argument3
%>
```
It adds more linebreaks, but I much prefer it.
I think it could be a configuration option if you (or other users) prefer the more condensed version.

### ERB inside HTML tags

Previous state:
```erb
<%# supported %>
<tag <% something %> />
<tag attr="<%= something %>" />
<tag attr="<% if a %>b<% end %>" />

<%# unsupported %>
<tag <%= something %> />
<tag <% if a %>b="c"<% end %> />
```

In my branch all of these cases are supported.

### `when 1, 2`

Previous state:
```erb
<%# supported %>
<% case foo %>
<% when 1 %>foo
<% end %>

<%# unsupported %>
<% case foo %>
<% when 1, 2 %>foo
<% end %>
```

In my branch comma-separated arguments are also supported.

### Formatting of keywords in ERB blocks

Previously code like below was possible
```erb
<%
if
  some_method(argument1, argument2, argument3)
%>
foo
<% end %>
```

In my branch keywords are formatted together with the rest of the Ruby code, so it looks better:
```erb
<%
  if some_method(argument1, argument2, argument3)
%>
foo
<% end %>
```

---

And that's it for now.

Let me know what you think.